### PR TITLE
[FEAT] VPC와 퍼플릭 Subnet 생성파일 정의

### DIFF
--- a/envs/koo-blog/main.tf
+++ b/envs/koo-blog/main.tf
@@ -1,0 +1,14 @@
+locals {
+  vpc_cidr       = "10.1.0.0/16"
+  public_subnets = {
+    cidrs = ["10.1.64.0/18"]
+    azs   = ["ap-northeast-2c"]
+  }
+}
+
+module "vpc" {
+  source = "../../modules/vpc"
+  vpc_name = "K00-Blog"
+  vpc_cidr = local.vpc_cidr
+  public_subnets = local.public_subnets
+}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,0 +1,21 @@
+resource "aws_vpc" "this" {
+  cidr_block = var.vpc_cidr
+
+  tags = {
+    Name      = "${var.vpc_name}"
+    ManagedBy = "Terraform"
+  }
+}
+
+resource "aws_subnet" "public" {
+  count      = length(var.public_subnets.cidrs)
+  vpc_id     = aws_vpc.this.id
+  cidr_block = var.public_subnets.cidrs[count.index]
+
+  availability_zone = var.public_subnets.azs[count.index]
+
+  tags = {
+    Name      = "${var.vpc_name}-public-subnet"
+    ManagedBy = "Terraform"
+  }
+}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -1,0 +1,15 @@
+variable "vpc_name" {
+  description = "VPC 이름. 관련 자원 이름의 Prefix로 사용합니다."
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "VPC의 IPv4 CIDR입니다."
+  type        = string
+}
+
+variable "public_subnets" {
+  description = "해당 VPC의 퍼블릭 서브넷의 CIDR 목록입니다."
+  type        = map(list(string))
+  default     = {}
+}


### PR DESCRIPTION
### 플랜 결과
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.vpc.aws_subnet.public[0] will be created
  + resource "aws_subnet" "public" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "ap-northeast-2c"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.1.64.0/18"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "ManagedBy" = "Terraform"
          + "Name"      = "K00-Blog-public-subnet"
        }
      + tags_all                                       = {
          + "ManagedBy" = "Terraform"
          + "Name"      = "K00-Blog-public-subnet"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.vpc.aws_vpc.this will be created
  + resource "aws_vpc" "this" {
      + arn                                  = (known after apply)
      + cidr_block                           = "10.1.0.0/16"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_dns_hostnames                 = (known after apply)
      + enable_dns_support                   = true
      + enable_network_address_usage_metrics = (known after apply)
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags                                 = {
          + "ManagedBy" = "Terraform"
          + "Name"      = "K00-Blog"
        }
      + tags_all                             = {
          + "ManagedBy" = "Terraform"
          + "Name"      = "K00-Blog"
        }
    }


```